### PR TITLE
Support psr/http-message v1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.3",
-    "psr/http-message": "^2.0"
+    "psr/http-message": "^1.0.1|^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
There are a few significant packages that `aws/aws-sdk-php` and `reactphp/http` that don't yet support v2.0 of `psr/http-message` from my testing it looks like your change work with v1.0.1 and this unblocks people with these packages which are used often with frameworks like Laravel.